### PR TITLE
Set encoding to prevent errors with characters during gradle build

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,6 +10,7 @@ dependencies {
 
 mainClassName = "TWEditor.Main"
 version = "3.0.1"
+[compileJava, compileTestJava]*.options*.encoding = 'UTF-8'
 
 launch4j {
     mainClassName = project.mainClassName


### PR DESCRIPTION
Gradle build was giving me errors with unclosed character and illegal character

This change sets the encoding to UTF-8